### PR TITLE
refactor: refactored function

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,13 +1,10 @@
 import { runTask } from './utils.js';
 
-runTask('pnpm run build', 'packages/shared', 'build').finally(() => {
-	runTask('pnpm run build', 'packages/utils/client', 'build').finally(() => {
-		runTask('pnpm run build', 'packages/utils/server', 'build').finally(() => {
-			runTask('pnpm run build', 'packages/icons', 'build').finally(() => {
-				runTask('pnpm run build', 'packages/server', 'build').finally(() => {
-					runTask('pnpm run build', 'packages/client', 'build').finally(() => {});
-				});
-			});
-		});
-	});
-});
+(async function () {
+	await runTask('pnpm run build', 'packages/shared', 'build');
+	await runTask('pnpm run build', 'packages/utils/client', 'build');
+	await runTask('pnpm run build', 'packages/utils/server', 'build');
+	await runTask('pnpm run build', 'packages/icons', 'build');
+	await runTask('pnpm run build', 'packages/server', 'build');
+	await runTask('pnpm run build', 'packages/client', 'build');
+})()


### PR DESCRIPTION
All those functions won't throw an Error, instead will just log that error, by which there's no need to `.finally`.